### PR TITLE
[Docs] Fix typos in documentation

### DIFF
--- a/docs/usage/consumer.rst
+++ b/docs/usage/consumer.rst
@@ -10,7 +10,7 @@ Creating a consumer
 -------------------
 
 One can obtain a :code:`Consumer` instance from a :code:`TopicHandle` the same way
-as producers, as examplified hereafter.
+as producers, as exemplified hereafter.
 
 .. tabs::
 

--- a/docs/usage/consumer.rst
+++ b/docs/usage/consumer.rst
@@ -36,7 +36,7 @@ A consumer can be created with five parameters, four of which are optional.
 * **Name**: the consumer name is mandatory. Mofka will keep track of the last event
   *acknowledged* by consumers, so that if an application stops and restarts with the
   same consumer name, it will restart consuming events from the last acknowledged event.
-  At present, :code:`Consumer`s with the same name should not pull from the same partition.
+  At present, :code:`Consumers` with the same name should not pull from the same partition.
 
 * **Batch size**: the batch size is the number of events to batch together on the server
   side before the batch is sent to the consumer. :code:`diaspora::BatchSize::Adaptive()`

--- a/docs/usage/consumer.rst
+++ b/docs/usage/consumer.rst
@@ -36,7 +36,7 @@ A consumer can be created with five parameters, four of which are optional.
 * **Name**: the consumer name is mandatory. Mofka will keep track of the last event
   *acknowledged* by consumers, so that if an application stops and restarts with the
   same consumer name, it will restart consuming events from the last acknowledged event.
-  At present, :code:`Consumers` with the same name should not pull from the same partition.
+  At present, :code:`Consumer`s with the same name should not pull from the same partition.
 
 * **Batch size**: the batch size is the number of events to batch together on the server
   side before the batch is sent to the consumer. :code:`diaspora::BatchSize::Adaptive()`

--- a/docs/usage/consumer.rst
+++ b/docs/usage/consumer.rst
@@ -78,7 +78,7 @@ A consumer can be created with five parameters, four of which are optional.
    in the code above (we could have, alternatively, not specified the :code:`thread_pool` argument
    at all).
 
-In Python, if your consumer intends to alway request the full data part of each event, and would
+In Python, if your consumer intends to always request the full data part of each event, and would
 like said data in the form of a :code:`bytearray`, you may use the :code:`FullDataSelector`
 and :code:`ByteArrayAllocator` from the :code:`diaspora_stream.api` module as data selector and
 data allocator respectively. These are variables, not classes. The latter will create a Python

--- a/docs/usage/consumer.rst
+++ b/docs/usage/consumer.rst
@@ -155,7 +155,7 @@ as shown in the picture bellow.
 
 The data selector is given a descriptor :code:`D` for the full data. :code:`D.size()`
 (:code:`D.size` in Python) will return :code:`W*H`. We can first use
-:code:`auto d1 = D.makeSubView(y*W + x, W*h)` (:code:`D.make_sub_view` in Python) to select
+:code:`auto d1 = D.makeSubView(y*W+x, W*h)` (:code:`D.make_sub_view` in Python) to select
 only the rows containing the rectangle we are interested in. This function takes the offset
 at which to start the selection and the size of the selection.
 

--- a/docs/usage/consumer.rst
+++ b/docs/usage/consumer.rst
@@ -155,7 +155,7 @@ as shown in the picture bellow.
 
 The data selector is given a descriptor :code:`D` for the full data. :code:`D.size()`
 (:code:`D.size` in Python) will return :code:`W*H`. We can first use
-:code:`audo d1 = D.makeSubView(y*W + x, W*h)` (:code:`D.make_sub_view` in Python) to select
+:code:`auto d1 = D.makeSubView(y*W + x, W*h)` (:code:`D.make_sub_view` in Python) to select
 only the rows containing the rectangle we are interested in. This function takes the offset
 at which to start the selection and the size of the selection.
 

--- a/docs/usage/deployment.rst
+++ b/docs/usage/deployment.rst
@@ -141,7 +141,7 @@ Copy the following *storage.jx9* file.
 .. literalinclude:: ../_code/storage-persistent-config.jx9
    :language: cpp
 
-This JX9 file contains is a script that mostly looks like the *storage.json* configuration we
+This JX9 file contains a script that mostly looks like the *storage.json* configuration we
 had before, except for the fact that this configuration is *returned* from the script after
 being completed with two parameters, :code:`$database_path` and :code:`$target_path`, which
 are themselves generated from an :code:`$id` parameter.

--- a/docs/usage/producer.rst
+++ b/docs/usage/producer.rst
@@ -92,7 +92,7 @@ The data part of an event would be the image itself.
 .. note::
 
    As of Mofka 0.4.0, the metadata part does not have to be JSON-formatted. A raw string
-   with any format may be used. the :code:`Metadata` class provides useful members functions
+   with any format may be used. The :code:`Metadata` class provides useful members functions
    such as :code:`json()` that will convert the content in JSON format in a lazy manner.
    Mofka itself won't use this function, and will not make assumption that the metadata is
    in JSON format.

--- a/docs/usage/producer.rst
+++ b/docs/usage/producer.rst
@@ -14,7 +14,7 @@ Creating a producer
 
 To obtain a :code:`Producer` instance, one must first instantiate a :code:`Driver`,
 before obtaining a :code:`TopicHandle` by opening a topic. The :code:`TopicHandle`
-can then be used to create a :code:`Producer`, as examplified hereafter.
+can then be used to create a :code:`Producer`, as exemplified hereafter.
 
 .. tabs::
 

--- a/docs/usage/producer.rst
+++ b/docs/usage/producer.rst
@@ -181,7 +181,7 @@ The producer's :code:`push` function takes the metadata and data objects and ret
 can be blocked on until it completes (:code:`future.wait()`). The latter method returns the
 event ID of the created event (64-bits unsigned integer).
 It is perfectly OK to drop the future if you do not care to wait for its completion or
-for the resulting event ID, as examplified with the second event. Event IDs are monotonically
+for the resulting event ID, as exemplified with the second event. Event IDs are monotonically
 increasing and are per-partition, so two events stored in distinct partitions can end up with the same ID.
 
 Calling :code:`producer.flush()` is a blocking call that will force all the pending batches of events

--- a/docs/usage/producer.rst
+++ b/docs/usage/producer.rst
@@ -51,7 +51,7 @@ A producer can be created with five optional parameters.
   producer will aim to send batches as soon as possible but will increase the batch size
   if the server is not responding fast enough.
 
-* **Maximum batches***: this parameter controls the maximum number of batches that can
+* **Maximum batches**: this parameter controls the maximum number of batches that can
   be pending on the client before :code:`push` calls start blocking. By default this number
   is 2 (i.e., one batch is being sent while the next one is being filled through :code:`push`
   calls). Increasing this number may be useful in bursty applications.

--- a/docs/usage/producer.rst
+++ b/docs/usage/producer.rst
@@ -177,7 +177,7 @@ into the producer, as shown in the code bellow.
 
 
 The producer's :code:`push` function takes the metadata and data objects and returns a
-:code:`Future`. Such a future can be tested for completion (:code:`future.completed`) and
+:code:`Future`. Such a future can be tested for completion (:code:`future.completed()`) and
 can be blocked on until it completes (:code:`future.wait()`). The latter method returns the
 event ID of the created event (64-bits unsigned integer).
 It is perfectly OK to drop the future if you do not care to wait for its completion or

--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -99,7 +99,7 @@ The sections hereafter show how to use both the C++ and Python interface to prod
 Simple producer application
 ---------------------------
 
-The following code examplifies a producer.
+The following code exemplifies a producer.
 We first create a :code:`Driver` object, passing it some options including the file
 created by our running Mofka server (*mofka.json*). Note that we are using the Diaspora
 API. The first argument passed to :code:`Driver::New`, "mofka", tells it to load the

--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -65,7 +65,7 @@ Creating a topic and a partition
 --------------------------------
 
 You can now use the :code:`mofkactl` command-line tool to create a topic.
-In a separate terminate, with your Spack environment activated, enter the following command.
+In a separate terminal, with your Spack environment activated, enter the following command.
 
 .. code-block:: bash
 

--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -162,7 +162,7 @@ last acknowledged event. This acknowledgement is done using the
 :code:`Event`'s :code:`acknowledge()` function, which in the example bellow
 is called every 10 events.
 
-:code:`consumer.pull()` is a non-blocking function returning a :code`Future`.
+:code:`consumer.pull()` is a non-blocking function returning a :code:`Future`.
 Waiting for this future with :code:`.wait()` returns an :code:`Event` object
 from which we can retrieve an event ID as well as the event's metadata and data.
 

--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -125,7 +125,7 @@ or a list of objects that satisfy the buffer protocol.
 
 The :code:`push()` function is non-blocking. It returns a future object that callers
 can wait on to obtain the event ID after the event has been stored. The call to :code:`wait()`
-in the code bellow is however commented: a better practice consists of periodically flushing
+in the code below is however commented: a better practice consists of periodically flushing
 the producer by calling :code:`producer.flush()`, or at least wait on futures as late as possible
 so as to overlap the sending of the event with actual work from the application.
 

--- a/docs/usage/topics.rst
+++ b/docs/usage/topics.rst
@@ -128,7 +128,7 @@ and serializer classes.
 .. literalinclude:: ../_code/energy_validator.cpp
    :language: cpp
 
-The :code:`EnergyValidator` class inherits from :code:`mofka::ValidatorInterface`
+The :code:`EnergyValidator` class inherits from :code:`diaspora::ValidatorInterface`
 and provides the :code:`validate` member function. This function checks for the
 presence of an :code:`energy` field of type unsigned integer and checks that
 its value is less than an :code:`energy_max` value provided when creating the
@@ -136,7 +136,7 @@ validator. If validation fails, the :code:`validate` function throws an exceptio
 
 .. important::
 
-   The :code:`MOFKA_REGISTER_VALIDATOR` macro must be used to tell Mofka
+   The :code:`DIASPORA_REGISTER_VALIDATOR` macro must be used to tell Mofka
    about the :code:`EnergyValidator` class. Its first argument is the name by
    which we will refer to the class in user code (*"energy_validator"*), the
    second argument is the name of the class itself (*EnergyValidator*).
@@ -146,8 +146,8 @@ validator. If validation fails, the :code:`validate` function throws an exceptio
 
 The :code:`EnergyPartitionSelector` is also initialized with an :code:`energy_max`
 value and uses it to aggregate events into uniform "bins" of similar energy values.
-It inherits from :code:`mofka::PartitionSelectorInterface` and we call
-:code:`MOFKA_REGISTER_PARTITION_SELECTOR` to make it available for Mofka to use.
+It inherits from :code:`diaspora::PartitionSelectorInterface` and we call
+:code:`DIASPORA_REGISTER_PARTITION_SELECTOR` to make it available for Mofka to use.
 
 .. literalinclude:: ../_code/energy_serializer.cpp
    :language: cpp
@@ -156,7 +156,7 @@ The :code:`EnergySerializer` is also initialized with an :code:`energy_max` valu
 This value is used to choose an appropriate number of bytes for the raw representation
 of the energy when it is serialized. :code:`EnergySerializer` inherits from
 :code:`SerializerInterface` and is registered with Mofka using
-:code:`MOFKA_REGISTER_SERIALIZER`.
+:code:`DIASPORA_REGISTER_SERIALIZER`.
 
 
 Adding partitions


### PR DESCRIPTION
This pull request primarily addresses documentation improvements by correcting typos, clarifying language, and updating code references for consistency and accuracy across several documentation files. The changes enhance readability and ensure that code examples and macro names are up to date with the current codebase.

Documentation corrections and clarifications:

* Fixed multiple typos and improved wording for clarity in `docs/usage/consumer.rst`, `docs/usage/producer.rst`, and `docs/usage/quickstart.rst` [[1]](diffhunk://#diff-201402d8c5cd8e95ec4cf147cab188fa009002e20e7e33e91a9e4bb208e9a934L13-R13) [[2]](diffhunk://#diff-201402d8c5cd8e95ec4cf147cab188fa009002e20e7e33e91a9e4bb208e9a934L81-R81) [[3]](diffhunk://#diff-201402d8c5cd8e95ec4cf147cab188fa009002e20e7e33e91a9e4bb208e9a934L158-R158) [[4]](diffhunk://#diff-4cdfee55e800e19127af8c33009fa870b90a34a3677735a10aaccf86c0548e8eL17-R17) [[5]](diffhunk://#diff-4cdfee55e800e19127af8c33009fa870b90a34a3677735a10aaccf86c0548e8eL54-R54) [[6]](diffhunk://#diff-4cdfee55e800e19127af8c33009fa870b90a34a3677735a10aaccf86c0548e8eL95-R95) [[7]](diffhunk://#diff-4cdfee55e800e19127af8c33009fa870b90a34a3677735a10aaccf86c0548e8eL180-R184) [[8]](diffhunk://#diff-fa31df20263d74dca2529211d7aad90bcf2ffa75f8ffebc3b25737d4841d41efL68-R68) [[9]](diffhunk://#diff-fa31df20263d74dca2529211d7aad90bcf2ffa75f8ffebc3b25737d4841d41efL102-R102) [[10]](diffhunk://#diff-fa31df20263d74dca2529211d7aad90bcf2ffa75f8ffebc3b25737d4841d41efL128-R128) [[11]](diffhunk://#diff-fa31df20263d74dca2529211d7aad90bcf2ffa75f8ffebc3b25737d4841d41efL165-R165) [[12]](diffhunk://#diff-18b103afc6dd63918c83ec617c4e9ee3102dcaf494d1ddf3797dfedeed9c657fL144-R144)

Code and macro reference updates:

* Updated class and macro references from `mofka::*` and `MOFKA_REGISTER_*` to `diaspora::*` and `DIASPORA_REGISTER_*` in `docs/usage/topics.rst` to match the current naming conventions in the codebase [[1]](diffhunk://#diff-16e6a274532952f881a68d4de97e8dabde40370349554863d6514234abd52317L131-R139) [[2]](diffhunk://#diff-16e6a274532952f881a68d4de97e8dabde40370349554863d6514234abd52317L149-R150) [[3]](diffhunk://#diff-16e6a274532952f881a68d4de97e8dabde40370349554863d6514234abd52317L159-R159)